### PR TITLE
仅处理 sync_dir 路径下 installation_id 对应目录的 .userdb.txt，兼容 fcitx5-android 输入法

### DIFF
--- a/lua/userdb_sync_delete.lua
+++ b/lua/userdb_sync_delete.lua
@@ -2,10 +2,45 @@
 function init(env)
     if not env.initialized then
         env.initialized = true
-        env.os_type = detect_os_type()  -- 全局变量，存储系统类型
-        env.pending_directories = {}  -- 用于保存所有待处理的目录路径
+        env.yaml_installation = detect_yaml_installation()  -- 解析 installation.yaml 文件，获取配置信息
+        env.os_type = detect_os_type(env)  -- 全局变量，存储系统类型
         env.total_deleted = 0  -- 记录删除的总条目数
     end
+end
+
+-- 解析 installation.yaml 文件
+function detect_yaml_installation()
+    local function trim(s)
+        return s:match("^%s*(.-)%s*$") or ""
+    end
+
+    local yaml = {}
+    local user_data_dir = rime_api.get_user_data_dir()
+    local yaml_path = user_data_dir .. "/installation.yaml"
+    local file, err  = io.open(yaml_path, "r")
+    if not file then
+        return yaml, "无法打开 installation.yaml 文件"
+    end
+
+    for line in file:lines() do
+        if not line:match("^%s*#") and not line:match("^%s*$") then
+            local key_part, value_part = line:match("^([^:]-):(.*)")
+            if key_part then
+                local key = trim(key_part)
+                local raw_value = trim(value_part)
+                if key ~= "" and raw_value ~= "" then
+                    local value = trim(raw_value)
+                    if #value >= 2 and value:sub(1,1) == '"' and value:sub(-1) == '"' then
+                        value = trim(value:sub(2, -2))
+                    end
+                    yaml[key] = value
+                end
+            end
+        end
+    end
+
+    file:close()
+    return yaml
 end
 
 -- 手动维护的操作系统检测模式表
@@ -16,37 +51,34 @@ local os_detection_patterns = {
     android = { "trime" }                -- android 的标识符
 }
 
--- 定义全局函数 detect_os_type
-function detect_os_type()
-    local user_data_dir = rime_api.get_user_data_dir()
-    local yaml_path = user_data_dir .. "/installation.yaml"
+-- 检查系统类型
+function detect_os_type(env)
+    local os_type = "unknown"
+    local dist_name = env.yaml_installation["distribution_code_name"]
 
-    -- 打开 installation.yaml 文件
-    local file, err = io.open(yaml_path, "r")
-    if not file then
-        return "unknown"
+    if not dist_name then
+        return os_type
     end
 
-    -- 遍历文件内容并检测 distribution_code_name 字段
-    local os_type = "unknown"
-    for line in file:lines() do
-        local dist_name = line:match('^%s*distribution_code_name:%s*"?([%w%-]+)"?')
-        if dist_name then
-            -- 遍历 os_detection_patterns 表来匹配系统类型
-            for os, patterns in pairs(os_detection_patterns) do
-                for _, pattern in ipairs(patterns) do
-                    if dist_name:match(pattern) then
-                        os_type = os
-                        break
-                    end
-                end
-                if os_type ~= "unknown" then break end
+    -- 遍历 os_detection_patterns 表来匹配系统类型
+    for os, patterns in pairs(os_detection_patterns) do
+        for _, pattern in ipairs(patterns) do
+            if dist_name:match(pattern) then
+                os_type = os
+                break
             end
-            break
+        end
+        if os_type ~= "unknown" then break end
+    end
+
+    -- android 使用 fcitx5-android 输入法会误识别为 linux，这里额外处理一下
+    if os_type == "linux" then
+        local user_data_dir = rime_api.get_user_data_dir()
+        if user_data_dir:match("^/org%.fcitx%.fcitx5%.android/$") then
+            os_type = "android"
         end
     end
 
-    file:close()  -- 关闭文件
     return os_type
 end
 
@@ -54,41 +86,27 @@ end
 function convert_path_separator(path, os_type)
     if os_type == "windows" then
         path = path:gsub("\\\\", "\\")  -- 将双反斜杠替换为单反斜杠
+        path = path:gsub("/", "\\")     -- 将斜杠替换为反斜杠
     end
     return path
 end
 
 -- 从 installation.yaml 文件中获取 sync_dir 路径
 function get_sync_path_from_yaml(env)
-    local user_data_dir = rime_api.get_user_data_dir()
-    local yaml_path = user_data_dir .. "/installation.yaml"
-
-    -- 使用标准 Lua io.open 打开文件
-    local file, err = io.open(yaml_path, "r")
-    if not file then
-        return nil, "无法打开 installation.yaml 文件"
+    local sync_dir = env.yaml_installation["sync_dir"]
+    if not sync_dir then
+        local user_data_dir = rime_api.get_user_data_dir()
+        sync_dir = user_data_dir .. "/sync"
     end
 
-    -- 读取文件并提取 sync_dir 的值
-    local sync_dir = nil
-    for line in file:lines() do
-        local key, value = line:match('(sync_dir):%s*"?(.-)"?%s*$')
-        if key and value then
-            sync_dir = value:match("^%s*(.-)%s*$")
-            sync_dir = convert_path_separator(sync_dir, env.os_type)  -- 根据系统类型转换路径分隔符
-            sync_dir = sync_dir:gsub('%"', '')  -- 去掉路径中的引号
-            break
-        end
+    local installation_id = env.yaml_installation["installation_id"]
+    if installation_id then
+        sync_dir = sync_dir .. "/" .. installation_id
     end
 
-    file:close()  -- 关闭文件
+    sync_dir = convert_path_separator(sync_dir, env.os_type)
 
-    if sync_dir then
-        return sync_dir, nil
-    else
-        local default_sync_dir = user_data_dir .. "/sync"  -- 与 installation.yaml 同级的 sync 目录
-        return default_sync_dir, nil
-    end
+    return sync_dir, nil
 end
 
 -- 捕获输入并执行相应的操作
@@ -101,12 +119,9 @@ function UserDictCleaner_process(key_event, env)
     if input == "/del" and env.initialized then
         env.total_deleted = 0  -- 重置计数器
 
-        local success, err = pcall(trigger_sync_cleanup, env)
-        if not success then
-            send_user_notification(0, env)  -- 清理操作失败时发送0
-        else
-            send_user_notification(env.total_deleted, env)
-        end
+        pcall(trigger_sync_cleanup, env)
+        send_user_notification(env.total_deleted, env) -- 失败情况下会发送0
+
         -- 清空输入内容，防止输入保留
         context:clear()
         return 1  -- 返回 1 表示已处理该事件
@@ -163,9 +178,30 @@ function generate_utf8_message(deleted_count)
     return "用户词典共清理 " .. tostring(deleted_count) .. " 行无效词条"
 end
 
--- 使用 os 执行不同的命令，列出文件
-function list_files(path, env)
-    local command = env.os_type == "windows" and ('dir "' .. path .. '" /b') or ('ls -1 "' .. path .. '"')
+-- 收集 path 目录下的目录，不含文件
+function list_dirs(path, os_type)
+    local command = os_type == "windows" and ('dir "'..path..'" /AD /B 2>nul') or ('ls -p "'..path..'" | grep / 2>/dev/null')
+    local handle = io.popen(command)
+    if not handle then
+        return nil, "无法遍历路径: " .. path
+    end
+
+    local dirs = {}
+    for dir in handle:lines() do
+        if dir:sub(-1) == "/" then
+            dir = dir:sub(1, -2)
+        end
+        local full_path = path .. "/" .. dir
+        full_path = convert_path_separator(full_path, os_type)
+        table.insert(dirs, full_path)
+    end
+    handle:close()
+    return dirs, nil
+end
+
+-- 收集 path 目录下的文件，不含目录
+function list_files(path, os_type)
+    local command = os_type == "windows" and ('dir "'..path..'" /A-D /B 2>nul') or ('ls -p "'..path..'" | grep -v / 2>/dev/null')
     local handle = io.popen(command)
     if not handle then
         return nil, "无法遍历路径: " .. path
@@ -173,66 +209,16 @@ function list_files(path, env)
 
     local files = {}
     for file in handle:lines() do
-        table.insert(files, file)
+        local full_path = path .. "/" .. file
+        full_path = convert_path_separator(full_path, os_type)
+        table.insert(files, full_path)
     end
     handle:close()
     return files, nil
 end
 
--- 递归删除 installation.yaml 同级目录下的 .userdb 文件夹
-function delete_userdb_folders(env)
-    local user_data_dir = rime_api.get_user_data_dir()
-    local files, err = list_files(user_data_dir, env)
-
-    if not files then
-        return
-    end
-
-    -- 遍历文件夹，删除以 .userdb 结尾的文件夹
-    for _, file in ipairs(files) do
-        if file:match("%.userdb$") then
-            local full_path = user_data_dir .. "/" .. file
-            if env.os_type == "windows" then
-                os.execute('rmdir /S /Q "' .. full_path .. '"')
-            else
-                os.execute('rm -rf "' .. full_path .. '"')
-            end
-        end
-    end
-end
-
--- 收集目录的函数
-function collect_directories(path, env)
-    local directories, err = list_files(path, env)
-    if not directories then
-        return
-    end
-
-    -- 将找到的所有目录添加到 pending_directories 列表
-    for _, dir in ipairs(directories) do
-        local full_path = path .. "/" .. dir
-        table.insert(env.pending_directories, full_path)
-    end
-end
-
--- 处理所有已收集的目录
-function process_collected_directories(env)
-    while #env.pending_directories > 0 do
-        local directory = table.remove(env.pending_directories)
-        local files, err = list_files(directory, env)
-        if not files then
-        else
-            for _, file in ipairs(files) do
-                if file:match("%.userdb%.txt$") then
-                    process_userdb_file(directory .. "/" .. file, env)
-                end
-            end
-        end
-    end
-end
-
 -- 处理 .userdb.txt 文件并删除 c < 0 条目的函数
-function process_userdb_file(file_path, env)
+function clean_userdb_file(file_path, env)
     local file, err = io.open(file_path, "r")
     if not file then
         return
@@ -275,22 +261,50 @@ function process_userdb_file(file_path, env)
     end
 end
 
--- 触发清理操作
-function trigger_sync_cleanup(env)
+-- 处理 .userdb.txt 文件并删除 c <= 0 条目
+function process_userdb_files(env)
     local sync_path, err = get_sync_path_from_yaml(env)
     if not sync_path then
-        send_user_notification(0, env)
         return
     end
 
-    -- 收集所有子目录
-    collect_directories(sync_path, env)
+    local files, err = list_files(sync_path, env.os_type)
+    if not files then
+        return
+    end
 
-    -- 处理所有收集到的目录
-    process_collected_directories(env)
+    for _, file in ipairs(files) do
+        if file:match("%.userdb%.txt$") then
+            clean_userdb_file(file, env)
+        end
+    end
+end
 
-    -- 删除 .userdb 文件夹
-    delete_userdb_folders(env)
+-- 删除 installation.yaml 同级目录下的 .userdb 文件夹
+function process_userdb_folders(env)
+    local user_data_dir = rime_api.get_user_data_dir()
+    local dirs, err = list_dirs(user_data_dir, env.os_type)
+
+    if not dirs then
+        return
+    end
+
+    -- 遍历文件夹，删除以 .userdb 结尾的文件夹
+    for _, dir in ipairs(dirs) do
+        if dir:match("%.userdb$") then
+            local command = env.os_type == "windows" and ('rmdir /S /Q "' .. dir .. '"') or ('rm -rf "' .. dir .. '"')
+            os.execute(command)
+        end
+    end
+end
+
+-- 触发清理操作
+function trigger_sync_cleanup(env)
+    -- 查找 .userdb.txt 文件，删除 c <= 0 条目
+    process_userdb_files(env)
+
+    -- 查找 .userdb 文件夹，删除
+    process_userdb_folders(env)
 end
 
 -- 返回初始化和处理函数


### PR DESCRIPTION
修改了 userdb_sync_delete.lua 部分代码，处理问题：
1. 原脚本会处理 sync_dir 路径下所有目录，如使用 sync_dir 目录进行多端同步容易出现异常现。现改为仅处理 sync_dir 路径下 installation_id 对应目录，不处理其他设备生成的 installation_id 目录。
2. 兼容 fcitx5-android 输入法识别，fcitx5-android 的 distribution_code_name 是 fcitx-rime，会被误识别成 linux。